### PR TITLE
Fix empty first page when no title content is provided

### DIFF
--- a/example/example.typ
+++ b/example/example.typ
@@ -7,7 +7,7 @@
   cover: image("img/party.png", height: 100%),
   paper: "a4",
   logo: image("img/GenericLogo.png", width: 13%),
-  fancy-author: true
+  fancy-author: true,
 )
 
 #outline(title: "Table of Contents\n")
@@ -29,7 +29,7 @@
   scope: "parent",
   clearance: 2em,
 )[
-= A headline that grabs your attention
+  = A headline that grabs your attention
 ]
 
 
@@ -55,7 +55,17 @@
 
 #lorem(85)
 
-#dndtab("Random occurences", [*d10*], [*Result*], [1], [A tingling in the extremities], [2-8], [Nothing interesting occurs], [10], [All the PCs burst into flame])
+#dndtab(
+  "Random occurences",
+  [*d10*],
+  [*Result*],
+  [1],
+  [A tingling in the extremities],
+  [2-8],
+  [Nothing interesting occurs],
+  [10],
+  [All the PCs burst into flame],
+)
 
 #lorem(150)
 
@@ -94,21 +104,36 @@ And more here!
   speed: [10ft, climb 10ft.],
   stats: (STR: 13, DEX: 14, CON: 18, INT: 5, WIS: 4, CHA: 7),
   skillblock: (
-      Skills: [Perception +6, Stealth +5],
-      Senses: [darkvision 60ft, passive Perception 13],
-      Languages: [-],
-      Challenge: [5 (1800 XP)]
+    Skills: [Perception +6, Stealth +5],
+    Senses: [darkvision 60ft, passive Perception 13],
+    Languages: [-],
+    Challenge: [5 (1800 XP)],
   ),
   traits: (
-    ("Scary Appearance", [While the monster is being ferocious, enemies are at -2 to all WIS saving throws.]), 
-    ("Reaching Tentacles", [The monster has six slimy tentacles. Each tentacle
-    can be attacked (AC 20; 10 hit points; immune to psychic damage). Destroying a tentacle makes the monster angry.])
-),
+    (
+      "Scary Appearance",
+      [While the monster is being ferocious, enemies are at -2 to all WIS saving throws.],
+    ),
+    (
+      "Reaching Tentacles",
+      [The monster has six slimy tentacles. Each tentacle
+        can be attacked (AC 20; 10 hit points; immune to psychic damage). Destroying a tentacle makes the monster angry.],
+    ),
+  ),
   Actions: (
-    ("Multiattack", [While the monster remains alive, it is a thorn in the party's side.]), 
-    ("Saliva", [If a character is eaten by the monster, it takes 1d10 saliva damage per round.]), 
-    ("Tentacle squeeze", [If the monster has captured an enemy, it can squeeze them for 1d12 crushing damage.])
-  )
+    (
+      "Multiattack",
+      [While the monster remains alive, it is a thorn in the party's side.],
+    ),
+    (
+      "Saliva",
+      [If a character is eaten by the monster, it takes 1d10 saliva damage per round.],
+    ),
+    (
+      "Tentacle squeeze",
+      [If the monster has captured an enemy, it can squeeze them for 1d12 crushing damage.],
+    ),
+  ),
 ))
 
 == A monster
@@ -149,24 +174,22 @@ And more here!
   name: "Dancing Legs",
   spell-type: [2nd level evocation],
   properties: (
-    ("Casting time", [Special]), 
-    ("Range", [Self]), 
-    ("Duration", [Until long rest]), 
-    ("Components", [V, S]), 
+    ("Casting time", [Special]),
+    ("Range", [Self]),
+    ("Duration", [Until long rest]),
+    ("Components", [V, S]),
   ),
-  description: [Your legs start dancing, and you dance compulsively, and in an experimental fashion. #lorem(20)]
-  )
-)
+  description: [Your legs start dancing, and you dance compulsively, and in an experimental fashion. #lorem(20)],
+))
 
 #spell((
   name: "Clapping Hands",
   spell-type: [2nd level evocation],
   properties: (
-    ("Casting time", [Special]), 
-    ("Range", [Self]), 
-    ("Duration", [Until long rest]), 
-    ("Components", [V, S]), 
+    ("Casting time", [Special]),
+    ("Range", [Self]),
+    ("Duration", [Until long rest]),
+    ("Components", [V, S]),
   ),
-  description: [Your legs start dancing, and you dance compulsively, and in an experimental fashion. #lorem(20)]
-  )
-)
+  description: [Your legs start dancing, and you dance compulsively, and in an experimental fashion. #lorem(20)],
+))

--- a/lib.typ
+++ b/lib.typ
@@ -73,10 +73,11 @@
     subtitle = subtitle + "\n"
   }
   
-  // FRONT PAGE
+  // FRONT PAGE — skip entirely when there's nothing to render on it
+  if add-title and (title.len() > 0 or subtitle.len() > 0 or logo != none or fancy-author or cover != none) {
   page(background: cover, margin: (top: 10mm, bottom: 5mm),
 columns: 1)[
-  #if add-title {
+  #if title.len() > 0 {
     place(
       top + center,
       box(fill: rgb("#00000066"), inset: 10%, text(fill: white, size: 60pt, weight: 800, upper(title)))
@@ -101,6 +102,7 @@ columns: 1)[
       place(dx: -10% + 0.7cm, dy: 73% + 0.7cm)[#text(size: 18pt, fill: white, weight: 700)[by #author]]
     }
   ]
+  }
   
   set text(size: font-size, lang: lang, fill: black)
 

--- a/lib.typ
+++ b/lib.typ
@@ -2,27 +2,29 @@
 #let darkyellow = rgb("#fcba03")
 #let dnd = smallcaps("Dungeons & Dragons")
 #let footer-content = context {
-      if here().page() > 1 {
-        place(left+bottom, image("img/footer.svg", width: 100%))
-        align(center)[#here().page()]
-      }
-    }
+  if here().page() > 1 {
+    place(left + bottom, image("img/footer.svg", width: 100%))
+    align(center)[#here().page()]
+  }
+}
 #let footer = state("footer", footer-content)
 
 #let language = state("language", toml("languages/en.toml"))
 
-#let dndmodule(title: "",
-              author: "",
-              subtitle: "",
-              cover: none,
-              font-size: 12pt,
-              paper: "a4",
-              logo: none,
-              fancy-author: false,
-              add-title: true,
-              bg: "default",
-              lang: "en",
-  body) = {
+#let dndmodule(
+  title: "",
+  author: "",
+  subtitle: "",
+  cover: none,
+  font-size: 12pt,
+  paper: "a4",
+  logo: none,
+  fancy-author: false,
+  add-title: true,
+  bg: "default",
+  lang: "en",
+  body,
+) = {
   set document(author: author, title: title)
   set par(spacing: 0.7em, first-line-indent: (amount: 1.5em, all: false))
   // set heading(numbering: "1.1")
@@ -40,15 +42,18 @@
   ))
 
   show heading.where(
-    level: 2
+    level: 2,
   ): it => block(text(
     size: 1.5em,
 
     fill: darkred,
     weight: "regular",
-
   )[
-    #box(width: 100%, inset: (bottom: 4pt), stroke: (bottom: 1pt + darkyellow))[#smallcaps(it.body)]
+    #box(
+      width: 100%,
+      inset: (bottom: 4pt),
+      stroke: (bottom: 1pt + darkyellow),
+    )[#smallcaps(it.body)]
   ])
 
   let bg-img = if bg == "default" {
@@ -58,91 +63,140 @@
   }
 
   // Page settings
-  set page(paper,
+  set page(
+    paper,
     flipped: false,
     margin: (left: 15mm, right: 15mm, top: 30mm, bottom: 30mm),
     numbering: "1",
     number-align: start,
     columns: 2,
     background: bg-img,
-    footer: context { footer.get()
+    footer: context {
+      footer.get()
       footer.update(footer-content)
-    }
-    )
+    },
+  )
   if subtitle.len() > 0 {
     subtitle = subtitle + "\n"
   }
-  
+
   // FRONT PAGE — skip entirely when there's nothing to render on it
-  if add-title and (title.len() > 0 or subtitle.len() > 0 or logo != none or fancy-author or cover != none) {
-  page(background: cover, margin: (top: 10mm, bottom: 5mm),
-columns: 1)[
-  #if title.len() > 0 {
-    place(
-      top + center,
-      box(fill: rgb("#00000066"), inset: 10%, text(fill: white, size: 60pt, weight: 800, upper(title)))
-    )
-   }
-
-    #if subtitle.len() > 0 {
-    place(
-      bottom + center,
-      dy: -0.2cm,
-      box(width: 80%, fill: rgb("#00000066"), inset: (left:10pt, right:10pt, top:10pt, bottom: 10pt), text(fill: white, size:20pt)[#subtitle #if not fancy-author {"by " + author}]
-    ))}
-
-    #if logo != none {
-      place(dx: 91%, dy: 100%-2.5cm,
-        logo // image("img/DMsGuildLogo.jpg", width: 13%)
+  if (
+    add-title
+      and (
+        title.len() > 0
+          or subtitle.len() > 0
+          or logo != none
+          or fancy-author
+          or cover != none
       )
-    }
+  ) {
+    page(background: cover, margin: (top: 10mm, bottom: 5mm), columns: 1)[
+      #if title.len() > 0 {
+        place(
+          top + center,
+          box(fill: rgb("#00000066"), inset: 10%, text(
+            fill: white,
+            size: 60pt,
+            weight: 800,
+            upper(title),
+          )),
+        )
+      }
 
-    #if fancy-author {
-      place(dx: -10%, dy: 73%, image("img/fire_splash.svg", width: 60%))
-      place(dx: -10% + 0.7cm, dy: 73% + 0.7cm)[#text(size: 18pt, fill: white, weight: 700)[by #author]]
-    }
-  ]
+      #if subtitle.len() > 0 {
+        place(
+          bottom + center,
+          dy: -0.2cm,
+          box(
+            width: 80%,
+            fill: rgb("#00000066"),
+            inset: (left: 10pt, right: 10pt, top: 10pt, bottom: 10pt),
+            text(fill: white, size: 20pt)[#subtitle #if not fancy-author {
+                "by " + author
+              }],
+          ),
+        )
+      }
+
+      #if logo != none {
+        place(
+          dx: 91%,
+          dy: 100% - 2.5cm,
+          logo, // image("img/DMsGuildLogo.jpg", width: 13%)
+        )
+      }
+
+      #if fancy-author {
+        place(dx: -10%, dy: 73%, image("img/fire_splash.svg", width: 60%))
+        place(dx: -10% + 0.7cm, dy: 73% + 0.7cm)[#text(
+          size: 18pt,
+          fill: white,
+          weight: 700,
+        )[by #author]]
+      }
+    ]
   }
-  
+
   set text(size: font-size, lang: lang, fill: black)
 
   body
-  
 }
 
 
 #let dndtab(name, columns: (1fr, 4fr), breakable: false, ..contents) = [
   #block(breakable: breakable)[
-  *#smallcaps(text(size: 1.3em)[#name])*
-  #v(-1em)
-  #table(
-  columns: columns,
-  align: (col, row) =>
-   if col == 0 { center }
-    else { left },
-  fill: (col, row) => if calc.odd(row+1) { rgb("#aaaaaa00") } else { rgb("#aaffaa33") },
-  inset: 10pt,
-  stroke: none,
-  // align: horizon,
-  ..contents
-  )
-]]
+    *#smallcaps(text(size: 1.3em)[#name])*
+    #v(-1em)
+    #table(
+      columns: columns,
+      align: (col, row) => if col == 0 { center } else { left },
+      fill: (col, row) => if calc.odd(row + 1) { rgb("#aaaaaa00") } else {
+        rgb("#aaffaa33")
+      },
+      inset: 10pt,
+      stroke: none,
+      // align: horizon,
+      ..contents
+    )
+  ]]
 
 
-#let topfig(figure) = [ #place(top + center, dy: -7em, dx:0em, float: true, scope: "parent", clearance: -6em, figure) ]
+#let topfig(figure) = [ #place(
+  top + center,
+  dy: -7em,
+  dx: 0em,
+  float: true,
+  scope: "parent",
+  clearance: -6em,
+  figure,
+) ]
 #let bottomfig(figure) = [ // Suppress the footer first
   #context footer.update("")
-  #place(bottom + center, dy: 7em, dx:0em, float: true, scope: "parent", clearance: -6em, figure)
+  #place(
+    bottom + center,
+    dy: 7em,
+    dx: 0em,
+    float: true,
+    scope: "parent",
+    clearance: -6em,
+    figure,
+  )
 ]
 
 
 #let breakoutbox(title, contents) = [#place(auto, float: true)[
   #set par(first-line-indent: 0em, spacing: 0.6em)
-  #box(inset: 10pt, width: 100%, stroke: (top: 2pt, bottom: 2pt), fill: rgb("#ddeedd"))[
+  #box(
+    inset: 10pt,
+    width: 100%,
+    stroke: (top: 2pt, bottom: 2pt),
+    fill: rgb("#ddeedd"),
+  )[
     #if title.len() > 0 {
       align(left, smallcaps[*#title*])
     }
-      
+
     #align(left)[#contents]
   ]
 ]]
@@ -152,7 +206,7 @@ columns: 1)[
   if i >= 10 {
     b = "+"
   }
-  b + str(calc.floor((i - 10)/2))
+  b + str(calc.floor((i - 10) / 2))
 }
 
 #let stat-to-str(a) = {
@@ -167,13 +221,25 @@ columns: 1)[
   for k in stats.values() {
     content.push([#text(fill: black, stat-to-str(k))])
   }
-  table(stroke: none, columns: (1fr, 1fr, 1fr, 1fr, 1fr, 1fr), inset: 0pt, row-gutter: 5pt, align: center, ..content)
+  table(stroke: none, columns: (
+      1fr,
+      1fr,
+      1fr,
+      1fr,
+      1fr,
+      1fr,
+    ), inset: 0pt, row-gutter: 5pt, align: center, ..content)
 }
 
 #let boxed-text(header, contents) = [
-  #box(inset: 10pt, fill: rgb("#fefff9"), stroke: (right: 1pt + darkyellow, left: 1pt + darkyellow), width: 100%)[
+  #box(
+    inset: 10pt,
+    fill: rgb("#fefff9"),
+    stroke: (right: 1pt + darkyellow, left: 1pt + darkyellow),
+    width: 100%,
+  )[
     #set par(spacing: .6em, first-line-indent: 1.5em)
-    #set text(size: 10pt) 
+    #set text(size: 10pt)
     #heading(outlined: false, level: 3, header)
     #v(0.5em)
     #contents
@@ -183,9 +249,9 @@ columns: 1)[
 #let statbox(stats) = [
   #box(inset: 12pt, fill: white, stroke: 1pt, width: 100%)[
     #set par(spacing: .6em)
-    #set text(size: 10pt) 
+    #set text(size: 10pt)
     #heading(outlined: false, level: 3, stats.name)
-    
+
     _ #stats.description _
 
     #line(stroke: 2pt + darkred, length: 100%)
@@ -194,7 +260,7 @@ columns: 1)[
       #text(fill: darkred)[*#language.get().stats.hp*] #stats.hp\
       #text(fill: darkred)[*#language.get().stats.speed*] #stats.speed\
     ]
-    
+
     #line(stroke: 2pt + darkred, length: 100%)
     #stats-table(stats.stats)
     #line(stroke: 2pt + darkred, length: 100%)
@@ -206,7 +272,7 @@ columns: 1)[
     #for trait in stats.traits {
       [ _*#trait.at(0).*_ #trait.at(1)]
     }
-    
+
     #context {
       let sections = (
         language.get().sections.actions,
@@ -219,7 +285,11 @@ columns: 1)[
         if section in stats.keys() {
           block[
             #set par(spacing: 1em)
-            #text(size: 1.3em, fill: darkred)[#box(width:100%, inset: (bottom: 3pt), stroke: (bottom: 1pt+darkyellow))[#smallcaps(section)]]
+            #text(size: 1.3em, fill: darkred)[#box(
+              width: 100%,
+              inset: (bottom: 3pt),
+              stroke: (bottom: 1pt + darkyellow),
+            )[#smallcaps(section)]]
             #for action in stats.at(section) {
               [_*#action.at(0).*_ #action.at(1) \ ]
             }
@@ -279,21 +349,18 @@ columns: 1)[
   _#spl.spell-type _
   #v(0.5em)
   #for prop in spl.properties {
-
-       [*#prop.at(0):* #prop.at(1) \ ]
-
-       
-      }
+    [*#prop.at(0):* #prop.at(1) \ ]
+  }
   #v(0.5em)
-  
+
   #spl.description
-  
+
 ]
 
 #let trademarks = text(size: 0.9em, style: "italic")[
   #dnd D&D, Wizards of the Coast, Forgotten Realms, Ravenloft, Eberron, the dragon ampersand, Ravnica and all other Wizards of the Coast product names, and their respective logos are trademarks of Wizards of the Coast in the USA and other countries.
 
-This work contains material that is copyright Wizards of the Coast and/or other authors. Such material is used with permission under the Community Content Agreement for Dungeon Masters Guild.
+  This work contains material that is copyright Wizards of the Coast and/or other authors. Such material is used with permission under the Community Content Agreement for Dungeon Masters Guild.
 
-All other original material in this work is copyright 2023 by the author and published under the Community Content Agreement for Dungeon Masters Guild.
+  All other original material in this work is copyright 2023 by the author and published under the Community Content Agreement for Dungeon Masters Guild.
 ]


### PR DESCRIPTION
## What & why

A document using `dndmodule` with no title, subtitle, logo, cover, or fancy-author still rendered an empty first page. The front page block ran unconditionally.

This guards the block so it only emits when there is content to show:

```typst
if add-title and (title.len() > 0 or subtitle.len() > 0 or logo != none or fancy-author or cover != none) {
```

The inner title placement also changed from `if add-title` to `if title.len() > 0`, so an enabled-but-empty title no longer draws an empty box.

## Commits

- **Fix empty first page when no title content is provided**: the minimal guard change.
- **Format source with typstyle 0.15.0**: ran `typstyle -i` on `lib.typ` and `example/example.typ`.
